### PR TITLE
rules/sdk: improve maps iteration check with more statement handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ IMAGE_REPO = securego
 BUILDFLAGS := '-w -s'
 CGO_ENABLED = 0
 GO := GO111MODULE=on go
-GO_NOMOD :=GO111MODULE=off go
 GOPATH ?= $(shell $(GO) env GOPATH)
 GOBIN ?= $(GOPATH)/bin
 GOLINT ?= $(GOBIN)/golint
@@ -17,9 +16,9 @@ default:
 	$(MAKE) build
 
 install-test-deps:
-	$(GO_NOMOD) get -u github.com/onsi/ginkgo/ginkgo
-	$(GO_NOMOD) get -u golang.org/x/crypto/ssh
-	$(GO_NOMOD) get -u github.com/lib/pq
+	go get -u github.com/onsi/ginkgo/ginkgo
+	go get -u golang.org/x/crypto/ssh
+	go get -u github.com/lib/pq
 
 test: install-test-deps build fmt lint sec
 	$(GINKGO) -r -v
@@ -31,7 +30,7 @@ fmt:
 
 lint:
 	@echo "LINTING"
-	$(GO_NOMOD) get -u golang.org/x/lint/golint
+	go get -u golang.org/x/lint/golint
 	$(GOLINT) -set_exit_status ./...
 	@echo "VETTING"
 	$(GO) vet ./...

--- a/rules/sdk/blocklist.go
+++ b/rules/sdk/blocklist.go
@@ -58,7 +58,7 @@ func NewBlocklistedImports(id string, conf gosec.Config, blocklist map[string]st
 	}, []ast.Node{(*ast.ImportSpec)(nil)}
 }
 
-// NewBlocklistedImportMD5 fails if MD5 is imported
+// NewUnsafeImport fails if any of "unsafe", "reflect", "crypto/rand", "math/rand" are imported.
 func NewUnsafeImport(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 	return NewBlocklistedImports(id, conf, map[string]string{
 		// unsafe exposes memory bugs

--- a/rules/sdk/errors.go
+++ b/rules/sdk/errors.go
@@ -78,7 +78,7 @@ func (r *noErrorCheck) Match(n ast.Node, ctx *gosec.Context) (*gosec.Issue, erro
 	return nil, nil
 }
 
-// NewNoErrorCheck detects if a returned error is not propagated up the stack.
+// NewErrorNotPropagated detects if a returned error is not propagated up the stack.
 func NewErrorNotPropagated(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 
 	return &noErrorCheck{

--- a/rules/sdk/strconv_bitsize_mismatch.go
+++ b/rules/sdk/strconv_bitsize_mismatch.go
@@ -137,6 +137,8 @@ func (bc *bitsizeOverflowCheck) Match(node ast.Node, ctx *gosec.Context) (*gosec
 	return nil, nil
 }
 
+// NewStrconvIntBitSizeOverflow returns an error if a constant bitSize is used
+// for a cast signed value that was retrieved from strconv.ParseUint.
 func NewStrconvIntBitSizeOverflow(id string, config gosec.Config) (rule gosec.Rule, nodes []ast.Node) {
 	calls := gosec.NewCallList()
 	calls.Add("strconv", "ParseUint")


### PR DESCRIPTION
Adds more robust checks for code paths that weren't properly handled/
This involves more diverse identifier pass handling plus determine
if we are dealing with map assignments, as well as diverse other kinds
of statements in a for-loop for map assignments.