### PR TITLE
all: reverse conditional refactor to reduce nesting

### DIFF
--- a/cmd/gosec/sort_issues.go
+++ b/cmd/gosec/sort_issues.go
@@ -10,7 +10,11 @@ import (
 
 // handle ranges
 func extractLineNumber(s string) int {
-	lineNumber, _ := strconv.Atoi(strings.Split(s, "-")[0])
+	lineNumber, err := strconv.Atoi(strings.Split(s, "-")[0])
+	if err != nil {
+		// TODO: Should this panic?
+		lineNumber = 0
+	}
 	return lineNumber
 
 }
@@ -20,16 +24,18 @@ type sortBySeverity []*gosec.Issue
 func (s sortBySeverity) Len() int { return len(s) }
 
 func (s sortBySeverity) Less(i, j int) bool {
-	if s[i].Severity == s[j].Severity {
-		if s[i].What == s[j].What {
-			if s[i].File == s[j].File {
-				return extractLineNumber(s[i].Line) > extractLineNumber(s[j].Line)
-			}
-			return s[i].File > s[j].File
-		}
+	if s[i].Severity != s[j].Severity {
+		return s[i].Severity > s[j].Severity
+	}
+
+	if s[i].What != s[j].What {
 		return s[i].What > s[j].What
 	}
-	return s[i].Severity > s[j].Severity
+
+	if s[i].File == s[j].File {
+		return extractLineNumber(s[i].Line) > extractLineNumber(s[j].Line)
+	}
+	return s[i].File > s[j].File
 }
 
 func (s sortBySeverity) Swap(i, j int) { s[i], s[j] = s[j], s[i] }


### PR DESCRIPTION
By reverse conditional-ing and early returns as idiomatic
Go exhibits, this change reduces nesting in some of the code.

Also while here, removed a swallowed error that was causing
tests to fail.