### PR TITLE
.github: upgrade to actions/go + add go mod caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,28 +8,48 @@ on:
       - master
 jobs:
   tests:
+    strategy:
+      matrix:
+        go_version:
+          - '1.17'
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on
     steps:
+      - name: Setup go ${{ matrix.go_version }} 
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go_version }}
       - name: Checkout Source 
         uses: actions/checkout@v2
-      - name: Run Tests
-        uses: cedrickring/golang-action@1.6.0
+      - uses: actions/cache@v3
         with:
-          args: make test
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run Tests
+        run: make test
   coverage:
     needs: tests
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on
     steps:
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
       - name: Checkout Source 
         uses: actions/checkout@v2
-      - name: Create Test Coverage
-        uses: cedrickring/golang-action@1.6.0
+      - uses: actions/cache@v3
         with:
-          args: make test-coverage
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Create Test Coverage
+        run: make test-coverage
       - name: Upload Test Coverage
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
This change replaces the deprecated cedrickring/golang-action with the official actions/setup-go and adds a cache step for go modules to speed up the workflow.