### PR TITLE
analyzer.go: add support for nested go modules

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -172,16 +172,15 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 		return nil, err
 	}
 	absGoModPath := absWorkingDir
-	for p := abspath; p != absWorkingDir; {
+	for p := abspath; p != absWorkingDir; p = filepath.Dir(p) {
 		if info, err := os.Stat(filepath.Join(p, "go.mod")); err == nil && !info.IsDir() {
 			absGoModPath = p
 			break
 		}
-		parentDir := filepath.Dir(p)
-		if parentDir == p {
+		// Break out if we've reached the root directory.
+		if strings.HasSuffix(p, string(filepath.Separator)) {
 			break
 		}
-		p = parentDir
 	}
 
 	// step 1/3 create build context.

--- a/analyzer.go
+++ b/analyzer.go
@@ -165,21 +165,36 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 	}
 
 	gosec.logger.Println("Import directory:", abspath)
+
+	// Find the deepest go.mod for the package.
+	absWorkingDir, err := GetPkgAbsPath(".")
+	if err != nil {
+		return nil, err
+	}
+	absGoModPath := absWorkingDir
+	for p := abspath; p != absWorkingDir; p = filepath.Dir(p) {
+		if info, err := os.Stat(filepath.Join(p, "go.mod")); err == nil && !info.IsDir() {
+			absGoModPath = p
+			break
+		}
+	}
+
 	// step 1/3 create build context.
 	buildD := build.Default
 	// step 2/3: add build tags to get env dependent files into basePackage.
 	buildD.BuildTags = conf.BuildFlags
-	basePackage, err := buildD.ImportDir(pkgPath, build.ImportComment)
+	buildD.Dir = absGoModPath
+	basePackage, err := buildD.ImportDir(abspath, build.ImportComment)
 	if err != nil {
 		return []*packages.Package{}, fmt.Errorf("importing dir %q: %v", pkgPath, err)
 	}
 
 	var packageFiles []string
 	for _, filename := range basePackage.GoFiles {
-		packageFiles = append(packageFiles, path.Join(pkgPath, filename))
+		packageFiles = append(packageFiles, path.Join(abspath, filename))
 	}
 	for _, filename := range basePackage.CgoFiles {
-		packageFiles = append(packageFiles, path.Join(pkgPath, filename))
+		packageFiles = append(packageFiles, path.Join(abspath, filename))
 	}
 
 	if gosec.tests {
@@ -187,12 +202,13 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 		testsFiles = append(testsFiles, basePackage.TestGoFiles...)
 		testsFiles = append(testsFiles, basePackage.XTestGoFiles...)
 		for _, filename := range testsFiles {
-			packageFiles = append(packageFiles, path.Join(pkgPath, filename))
+			packageFiles = append(packageFiles, path.Join(abspath, filename))
 		}
 	}
 
 	// step 3/3 remove build tags from conf to proceed build correctly.
 	conf.BuildFlags = nil
+	conf.Dir = absGoModPath
 	pkgs, err := packages.Load(conf, packageFiles...)
 	if err != nil {
 		return []*packages.Package{}, fmt.Errorf("loading files from package %q: %v", pkgPath, err)

--- a/analyzer.go
+++ b/analyzer.go
@@ -166,17 +166,22 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 
 	gosec.logger.Println("Import directory:", abspath)
 
-	// Find the deepest go.mod for the package.
+	// Find the deepest go.mod for the package, defaulting to the working directory.
 	absWorkingDir, err := GetPkgAbsPath(".")
 	if err != nil {
 		return nil, err
 	}
 	absGoModPath := absWorkingDir
-	for p := abspath; p != absWorkingDir; p = filepath.Dir(p) {
+	for p := abspath; p != absWorkingDir; {
 		if info, err := os.Stat(filepath.Join(p, "go.mod")); err == nil && !info.IsDir() {
 			absGoModPath = p
 			break
 		}
+		parentDir := filepath.Dir(p)
+		if parentDir == p {
+			break
+		}
+		p = parentDir
 	}
 
 	// step 1/3 create build context.


### PR DESCRIPTION
This change adds support for analyzing projects with more than one go.mod. This will let us run this tool on https://github.com/cosmos/cosmos-sdk

Updates https://github.com/cosmos/cosmos-sdk/issues/10572
Related: https://github.com/securego/gosec/issues/501