### PR TITLE
rules/sdk: permit map copying in G705

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -356,8 +356,6 @@ func (gosec *Analyzer) Visit(n ast.Node) ast.Visitor {
 	// Now create the union of exclusions.
 	ignores := map[string]bool{}
 	if len(gosec.context.Ignores) > 0 {
-		// TODO(https://github.com/informalsystems/gosec/issues/24): Map copying is currently incorrectly flagged by G705. When this is fixed, we can remove the below annotation.
-		// #nosec G705
 		for k, v := range gosec.context.Ignores[0] {
 			ignores[k] = v
 		}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/nxadm/tail v1.4.8 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
-	golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 // indirect
+	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 h1:z8Hj/bl9cOV2grsOpEaQFUaly0JWN3i97mo3jXKJNp0=
-golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c h1:aFV+BgZ4svzjfabn8ERpuB4JI4N6/rdy1iusx77G3oU=
+golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -2508,6 +2508,13 @@ func main() {
 	for k := range do() {
 		{}
 	}
+
+	// Map copying should be permitted.
+	from := make(map[string]string, 0)
+	to := make(map[string]string, len(a))
+	for k, v := range from {
+		to[k] = v
+	}
 }
 
 func do() map[string]string { return nil }


### PR DESCRIPTION
This change permits map copies of the form:
```go
for k, v := range from {
    to[k] = v
}
```

It doesn't currently permit the alternative, which trickier to check for and doesn't really have any benefits:
```go
for k := range from {
  to[k] = from[k]
}
```


Updates #24