### PR TITLE
rules/sdk: permit additional map copying format

### DIFF
--- a/rules/sdk/iterate_over_maps.go
+++ b/rules/sdk/iterate_over_maps.go
@@ -217,12 +217,7 @@ func isMapCopy(ctx *gosec.Context, stmt *ast.AssignStmt, rangeStmt *ast.RangeStm
 	printer.Fprint(rangeXString, ctx.FileSet, rangeStmt.X)
 	indexExprXString := &bytes.Buffer{}
 	printer.Fprint(indexExprXString, ctx.FileSet, indexExpr.X)
-
-	if bytes.Equal(rangeXString.Bytes(), indexExprXString.Bytes()) {
-		return true, nil
-	}
-	panic(fmt.Sprintf("asdfasdf: (%s) (%s)\n", rangeXString.String(), indexExprXString.String()))
-
+	return bytes.Equal(rangeXString.Bytes(), indexExprXString.Bytes()), nil
 }
 
 func onlyAppendCall(callExpr *ast.CallExpr) (string, bool) {

--- a/rules/sdk/iterate_over_maps.go
+++ b/rules/sdk/iterate_over_maps.go
@@ -214,9 +214,15 @@ func isMapCopy(ctx *gosec.Context, stmt *ast.AssignStmt, rangeStmt *ast.RangeStm
 
 	// 2. Ensure that the map being read in stmt.Rhs is the same as the source map (rangeStmt.X).
 	rangeXString := &bytes.Buffer{}
-	printer.Fprint(rangeXString, ctx.FileSet, rangeStmt.X)
+	err := printer.Fprint(rangeXString, ctx.FileSet, rangeStmt.X)
+	if err != nil {
+		return false, err
+	}
 	indexExprXString := &bytes.Buffer{}
-	printer.Fprint(indexExprXString, ctx.FileSet, indexExpr.X)
+	err = printer.Fprint(indexExprXString, ctx.FileSet, indexExpr.X)
+	if err != nil {
+		return false, err
+	}
 	return bytes.Equal(rangeXString.Bytes(), indexExprXString.Bytes()), nil
 }
 

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -2515,6 +2515,12 @@ func main() {
 	for k, v := range from {
 		to[k] = v
 	}
+	for k := range from {
+		to[k] = from[k]
+	}
+	for k := range do() {
+		to[k] = do()[k]
+	}
 }
 
 func do() map[string]string { return nil }


### PR DESCRIPTION
This change adds support for map copying of the form:
```go
for k := range from {
  to[k] = from[k]
}
```

This should include edge cases like if the result of a function call or array access is being iterated over rather than a plain identifier, because this change uses a string comparison to ensure that the expression in the range statement is the same as the one being read in the body.

Updates #24